### PR TITLE
Added Exception logging events to the interface

### DIFF
--- a/NLog.Interface/ILogger.cs
+++ b/NLog.Interface/ILogger.cs
@@ -207,6 +207,12 @@ namespace NLog.Interface
         /// <param name="argument3">The third argument to format.</param>
         void Log<TArgument1, TArgument2, TArgument3>(LogLevel level, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
+		/// <summary>
+		/// Writes the diagnostic message and exception at the <c>Trace</c> level.
+		/// </summary>
+		/// <param name="message">A <see langword="string"/> to be written.</param><param name="exception">An exception to be logged.</param>
+		void TraceException([Localizable(false)] string message, Exception exception);
+
         /// <overloads>
         /// Writes the diagnostic message at the <c>Trace</c> level using the specified format provider and format parameters.
         /// </overloads>
@@ -321,6 +327,12 @@ namespace NLog.Interface
         /// <param name="argument2">The second argument to format.</param>
         /// <param name="argument3">The third argument to format.</param>
         void Trace<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+
+		/// <summary>
+		/// Writes the diagnostic message and exception at the <c>Debug</c> level.
+		/// </summary>
+		/// <param name="message">A <see langword="string"/> to be written.</param><param name="exception">An exception to be logged.</param>
+		void DebugException([Localizable(false)] string message, Exception exception);
 
         /// <overloads>
         /// Writes the diagnostic message at the <c>Debug</c> level using the specified format provider and format parameters.
@@ -437,6 +449,12 @@ namespace NLog.Interface
         /// <param name="argument3">The third argument to format.</param>
         void Debug<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
+		/// <summary>
+		/// Writes the diagnostic message and exception at the <c>Info</c> level.
+		/// </summary>
+		/// <param name="message">A <see langword="string"/> to be written.</param><param name="exception">An exception to be logged.</param>
+		void InfoException([Localizable(false)] string message, Exception exception);
+
         /// <overloads>
         /// Writes the diagnostic message at the <c>Info</c> level using the specified format provider and format parameters.
         /// </overloads>
@@ -551,6 +569,12 @@ namespace NLog.Interface
         /// <param name="argument2">The second argument to format.</param>
         /// <param name="argument3">The third argument to format.</param>
         void Info<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+		
+		/// <summary>
+		/// Writes the diagnostic message and exception at the <c>Warn</c> level.
+		/// </summary>
+		/// <param name="message">A <see langword="string"/> to be written.</param><param name="exception">An exception to be logged.</param>
+		void WarnException([Localizable(false)] string message, Exception exception);
 
         /// <overloads>
         /// Writes the diagnostic message at the <c>Warn</c> level using the specified format provider and format parameters.
@@ -667,6 +691,12 @@ namespace NLog.Interface
         /// <param name="argument3">The third argument to format.</param>
         void Warn<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
+		/// <summary>
+		/// Writes the diagnostic message and exception at the <c>Error</c> level.
+		/// </summary>
+		/// <param name="message">A <see langword="string"/> to be written.</param><param name="exception">An exception to be logged.</param>
+		void ErrorException([Localizable(false)] string message, Exception exception);
+
         /// <overloads>
         /// Writes the diagnostic message at the <c>Error</c> level using the specified format provider and format parameters.
         /// </overloads>
@@ -781,6 +811,12 @@ namespace NLog.Interface
         /// <param name="argument2">The second argument to format.</param>
         /// <param name="argument3">The third argument to format.</param>
         void Error<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+
+		/// <summary>
+		/// Writes the diagnostic message and exception at the <c>Fatal</c> level.
+		/// </summary>
+		/// <param name="message">A <see langword="string"/> to be written.</param><param name="exception">An exception to be logged.</param>
+		void FatalException([Localizable(false)] string message, Exception exception);
 
         /// <overloads>
         /// Writes the diagnostic message at the <c>Fatal</c> level using the specified format provider and format parameters.

--- a/NLog.Interface/LoggerAdapter.cs
+++ b/NLog.Interface/LoggerAdapter.cs
@@ -125,6 +125,11 @@ namespace NLog.Interface
             _logger.Log(level, message, argument1, argument2, argument3);
         }
 
+		public void TraceException(string message, Exception exception)
+		{
+			_logger.TraceException(message, exception);
+		}
+
         public void Trace<T>(T value)
         {
             _logger.Trace(value);
@@ -189,6 +194,11 @@ namespace NLog.Interface
         {
             _logger.Trace(message, argument1, argument2, argument3);
         }
+
+		public void DebugException(string message, Exception exception)
+		{
+			_logger.DebugException(message, exception);
+		}
 
         public void Debug<T>(T value)
         {
@@ -255,6 +265,11 @@ namespace NLog.Interface
             _logger.Debug(message, argument1, argument2, argument3);
         }
 
+		public void InfoException(string message, Exception exception)
+		{
+			_logger.InfoException(message, exception);
+		}
+
         public void Info<T>(T value)
         {
             _logger.Info(value);
@@ -319,6 +334,11 @@ namespace NLog.Interface
         {
             _logger.Info(message, argument1, argument2, argument3);
         }
+
+		public void WarnException(string message, Exception exception)
+		{
+			_logger.WarnException(message, exception);
+		}
 
         public void Warn<T>(T value)
         {
@@ -385,6 +405,11 @@ namespace NLog.Interface
             _logger.Warn(message, argument1, argument2, argument3);
         }
 
+		public void ErrorException(string message, Exception exception)
+		{
+			_logger.ErrorException(message, exception);
+		}
+
         public void Error<T>(T value)
         {
             _logger.Error(value);
@@ -449,6 +474,11 @@ namespace NLog.Interface
         {
             _logger.Error(message, argument1, argument2, argument3);
         }
+
+		public void FatalException(string message, Exception exception)
+		{
+			_logger.FatalException(message, exception);
+		}
 
         public void Fatal<T>(T value)
         {


### PR DESCRIPTION
Hey,

I've added the Exception logging methods to the interface and adapter e.g. DebugException and InfoException. We use these extensively where I currently work, but we previously weren't using DI for logging.

Hope this helps

Ryan Bartsch.